### PR TITLE
NETBEANS-5004

### DIFF
--- a/vars/asfMainNetBeansBuild.groovy
+++ b/vars/asfMainNetBeansBuild.groovy
@@ -326,6 +326,7 @@ def doParallelClusters(cconfigs) {
                                 sh "cp build-${clustername}-temp/nbbuild/binaries-default-properties.xml distpreparation${versionnedpath}installer/nbbuild/binaries-default-properties.xml "
                                 sh "mkdir -p distpreparation${versionnedpath}installer/nbbuild/build/ && cp -r build-${clustername}-temp/nbbuild/build/antclasses distpreparation${versionnedpath}installer/nbbuild/build/antclasses "
                                         
+                                sh "mkdir -p distpreparation${versionnedpath}installer/nb/ide.launcher && cp -r build-${clustername}-temp/nb/ide.launcher/macosx distpreparation${versionnedpath}installer/nb/ide.launcher "
                                         
                                         
                                 sh "cp build-${clustername}-temp/nbbuild/*${clustername}*.zip dist${versionnedpath}${path}-${rmversion}-bin.zip"


### PR DESCRIPTION
Added a new copy step into the build file so that the updated files needed for the MACOSX installer are copied into the distpreparations folder for ease of installer generation.

See https://github.com/apache/netbeans/pull/2563 for info.