### PR TITLE
Registering the branch commit of VSNetBeans 12.4.301 preview

### DIFF
--- a/meta/netbeansrelease.json
+++ b/meta/netbeansrelease.json
@@ -454,7 +454,7 @@
         "plugin_url": "https://netbeans.apache.org/nb/plugins/12.4/catalog.xml.gz",
         "milestones": {
             "d26abee5706b6a1c7cd8ae6589d059b45144576a": {
-                "version": "vc1",
+                "vote": "1",
                 "position": "1"
             }
         },

--- a/meta/netbeansrelease.json
+++ b/meta/netbeansrelease.json
@@ -449,7 +449,7 @@
         "maven": "maven_3.3.9",
         "versionName": "12.4.301",
         "tlp": "true",
-        "apidocurl": "https://bits.netbeans.org/12.4/javadoc",
+        "apidocurl": "https://bits.netbeans.org/12.4.301/javadoc",
         "update_url": "https://netbeans.apache.org/nb/updates/12.4/updates.xml.gz?{$netbeans.hash.code}",
         "plugin_url": "https://netbeans.apache.org/nb/plugins/12.4/catalog.xml.gz",
         "milestones": {

--- a/meta/netbeansrelease.json
+++ b/meta/netbeansrelease.json
@@ -441,6 +441,34 @@
             "year": "2021"
         }
     },
+    "release1243": {
+        "position": "12",
+        "ant": "ant_latest",
+        "jdk": "jdk_1.8_latest",
+        "jdk_apidoc": "https://docs.oracle.com/javase/8/docs/api/",
+        "maven": "maven_3.3.9",
+        "versionName": "12.4.301",
+        "tlp": "true",
+        "apidocurl": "https://bits.netbeans.org/12.4/javadoc",
+        "update_url": "https://netbeans.apache.org/nb/updates/12.4/updates.xml.gz?{$netbeans.hash.code}",
+        "plugin_url": "https://netbeans.apache.org/nb/plugins/12.4/catalog.xml.gz",
+        "milestones": {
+            "d26abee5706b6a1c7cd8ae6589d059b45144576a": {
+                "version": "vc1",
+                "position": "1"
+            }
+        },
+        "releasedate": {
+            "day": "14",
+            "month": "07",
+            "year": "2021"
+        },
+        "previousreleasedate": {
+            "day": "19",
+            "month": "05",
+            "year": "2021"
+        }
+    },
     "master": {
         "position": "50000",
         "ant": "ant_latest",

--- a/meta/netbeansrelease.json
+++ b/meta/netbeansrelease.json
@@ -453,7 +453,7 @@
         "update_url": "https://netbeans.apache.org/nb/updates/12.4/updates.xml.gz?{$netbeans.hash.code}",
         "plugin_url": "https://netbeans.apache.org/nb/plugins/12.4/catalog.xml.gz",
         "milestones": {
-            "d26abee5706b6a1c7cd8ae6589d059b45144576a": {
+            "cd6bfbc00a8ae58191e3c442492aa9e4fd5137bb": {
                 "vote": "1",
                 "position": "1"
             }


### PR DESCRIPTION
I have created the [vsnetbeans_preview_1243](https://github.com/apache/netbeans/tree/vsnetbeans_preview_1243) branch and launched the [VC1 build](https://ci-builds.apache.org/job/Netbeans/job/netbeans-vscode/485/). It's release co-ordinates aren't correct and this PR is my attempt to fix them.

I decided to use update centers for 12.4 as they are unlikely to change much. I called the release `12.4.301`. I am not sure whether that's the best, but it is at least start.