### PR TITLE
Documenting HTML/Java release 1.7.2

### DIFF
--- a/meta/netbeanshtml4j.json
+++ b/meta/netbeanshtml4j.json
@@ -47,6 +47,14 @@
         "tlp": "true",
         "apidocurl": "https://bits.netbeans.org/html+java/1.7.1"
     },
+    "release-1.7.2": {
+        "position": "7",
+        "jdk": "jdk_15_latest",
+        "jdk_apidoc": "https://docs.oracle.com/javase/8/docs/api/",
+        "version": "1.7.2",
+        "tlp": "true",
+        "apidocurl": "https://bits.netbeans.org/html+java/1.7.2"
+    },
     "master": {
         "position": "40000",
         "jdk": "jdk_1.8_latest",


### PR DESCRIPTION
Looks like the [release 1.7.2](https://github.com/apache/netbeans-html4j/tree/release-1.7.2) of HTML/Java API Javadoc isn't listed at https://bits.netbeans.org/ - this PR is my attempt to fix that.