### PR TITLE
Remove apidoc url for 12.4.301

### DIFF
--- a/meta/netbeansrelease.json
+++ b/meta/netbeansrelease.json
@@ -449,7 +449,7 @@
         "maven": "maven_3.3.9",
         "versionName": "12.4.301",
         "tlp": "true",
-        "apidocurl": "https://bits.netbeans.org/12.4.301/javadoc",
+        "apidocurl": "",
         "update_url": "https://netbeans.apache.org/nb/updates/12.4/updates.xml.gz?{$netbeans.hash.code}",
         "plugin_url": "https://netbeans.apache.org/nb/plugins/12.4/catalog.xml.gz",
         "milestones": {


### PR DESCRIPTION
Remove apidocurl - looking at validating and filtering by url on publishing side.

@ebarboni is this safe?  Or is the value used anywhere else?  Can add another flag if necessary.