### PR TITLE
Registering interim preview release of VSNetBeans 12.5.301

### DIFF
--- a/meta/netbeansrelease.json
+++ b/meta/netbeansrelease.json
@@ -514,7 +514,7 @@
         "maven": "maven_3.3.9",
         "versionName": "12.5.301",
         "tlp": "true",
-        "apidocurl": "",
+        "apidocurl": "https://bits.netbeans.org/12.5/javadoc",
         "update_url": "https://netbeans.apache.org/nb/updates/12.5/updates.xml.gz?{$netbeans.hash.code}",
         "plugin_url": "https://netbeans.apache.org/nb/plugins/12.5/catalog.xml.gz",
         "milestones": {


### PR DESCRIPTION
Registering 12.5.301 release as announce at [mailing list](https://lists.apache.org/thread.html/r9987127803d5914c1180681d6dee64d0357abf4085c6ea1cca95e22c%40%3Cdev.netbeans.apache.org%3E) based on [this changeset](https://github.com/apache/netbeans/commit/b19730846d986575f26b3b70236d2142dde18157).

The bits are (likely to be) generated at&by [vscode@650](https://ci-builds.apache.org/job/Netbeans/job/netbeans-vscode/650).  I had to provide a URL for API doc in a5272be otherwise my release info is removed by [this removeIf statement](https://github.com/apache/netbeans/blob/a3028ba54c83b0bdbf0124b44fc7d6570378b8cd/nbbuild/antsrc/org/netbeans/nbbuild/ReleaseJsonProperties.java#L119).