### PR TITLE
HTML/Java 1.7.3

### DIFF
--- a/meta/netbeanshtml4j.json
+++ b/meta/netbeanshtml4j.json
@@ -55,6 +55,14 @@
         "tlp": "true",
         "apidocurl": "https://bits.netbeans.org/html+java/1.7.2"
     },
+    "release-1.7.3": {
+        "position": "8",
+        "jdk": "jdk_15_latest",
+        "jdk_apidoc": "https://docs.oracle.com/javase/8/docs/api/",
+        "version": "1.7.3",
+        "tlp": "true",
+        "apidocurl": "https://bits.netbeans.org/html+java/1.7.3"
+    },
     "master": {
         "position": "40000",
         "jdk": "jdk_1.8_latest",


### PR DESCRIPTION
Assuming [the vote](https://lists.apache.org/thread/jc0zypw8hcg0826t0vwdwtsydb9przmv) passes, we shall record HTML/Java 1.7.3 release among all the releases.