### PR TITLE
Meta information for VSNetBeans 12.6.301

### DIFF
--- a/meta/netbeansrelease.json
+++ b/meta/netbeansrelease.json
@@ -586,6 +586,35 @@
             "year": "2021"
         }
     },
+    "release1263": {
+        "position": "16",
+        "ant": "ant_latest",
+        "jdk": "jdk_1.8_latest",
+        "jdk_apidoc": "https://docs.oracle.com/javase/8/docs/api/",
+        "maven": "maven_3.3.9",
+        "versionName": "12.6.301",
+        "tlp": "true",
+        "apidocurl": "https://bits.netbeans.org/12.6/javadoc",
+        "update_url": "https://netbeans.apache.org/nb/updates/12.6/updates.xml.gz?{$netbeans.hash.code}",
+        "plugin_url": "https://netbeans.apache.org/nb/plugins/12.6/catalog.xml.gz",
+        "publish_apidoc":"false",
+        "milestones": {
+            "e38a4a3e560418b45d0900cae2cfdc4cdd333f8f": {
+                "vote": "1",
+                "position": "1"
+            }
+        },
+        "releasedate": {
+            "day": "16",
+            "month": "1",
+            "year": "2022"
+        },
+        "previousreleasedate": {
+            "day": "29",
+            "month": "11",
+            "year": "2021"
+        }
+    },
     "master": {
         "position": "50000",
         "ant": "ant_latest",


### PR DESCRIPTION
Preparing release of VSCode NetBeans extension 12.6.301 from branch [vsnetbeans_preview_1263](https://github.com/apache/netbeans/tree/vsnetbeans_preview_1263).