### PR TITLE
Remove alternative path for voting build artefacts.

### DIFF
--- a/vars/asfMainNetBeansBuild.groovy
+++ b/vars/asfMainNetBeansBuild.groovy
@@ -223,9 +223,6 @@ def call(Map params = [:]) {
 
                         def clusterconfigs = [['platform','netbeans-platform'],['release','netbeans']]
 
-                        if (votecandidate) {
-                            versionpath = "${version}/vc${vote}/"
-                        }
                         doParallelClusters(clusterconfigs);
                     }
                 }


### PR DESCRIPTION
Remove alternative path used when building a vote candidate. @ebarboni I don't think this serves any purpose any more?  And it breaks the temporary redirect on the VM for update centres that points to `https://ci-builds.apache.org/job/Netbeans/job/netbeans-TLP/job/netbeans/job/release130/lastSuccessfulBuild/artifact/dist/netbeans/nbms/$1`