### PR TITLE
VSNetBeans 15.0.301 release metadata

### DIFF
--- a/meta/netbeansrelease.json
+++ b/meta/netbeansrelease.json
@@ -818,6 +818,36 @@
             "year": "2022"
         }
     },
+    "release1503": {
+        "position": "22",
+        "ant": "ant_latest",
+        "jdk": "jdk_11_latest",
+        "jdk_apidoc": "https://docs.oracle.com/en/java/javase/11/docs/api/",
+        "maven": "maven_3_latest",
+        "versionName": "15.0.301",
+        "vsixVersion": "15.0.301",
+        "tlp": "true",
+        "apidocurl": "https://bits.netbeans.org/15/javadoc",
+        "update_url": "https://netbeans.apache.org/nb/updates/15/updates.xml.gz?{$netbeans.hash.code}",
+        "plugin_url": "https://netbeans.apache.org/nb/plugins/15/catalog.xml.gz",
+        "publish_apidoc":"false",
+        "milestones": {
+            "a15f69c14c82041feb079d4e8a3dabc451f7d474": {
+                "vote": "1",
+                "position": "1"
+            }
+        },
+        "releasedate": {
+            "day": "14",
+            "month": "10",
+            "year": "2022"
+        },
+        "previousreleasedate": {
+            "day": "26",
+            "month": "08",
+            "year": "2022"
+        }
+    },
     "master": {
         "position": "50000",
         "ant": "ant_latest",


### PR DESCRIPTION
Release metadata for VSCode NetBeans extension rel. 15.0.301.
Will merge this when build of 15.0.301 VSIX passes.