### PR TITLE
allow another jdk for apidoc

### DIFF
--- a/meta/netbeansrelease.json
+++ b/meta/netbeansrelease.json
@@ -968,6 +968,7 @@
         "position": "50000",
         "ant": "ant_latest",
         "jdk": "jdk_11_latest",
+        "jdktoolapidoc" : "jdk_19_latest",
         "jdk_apidoc": "https://docs.oracle.com/en/java/javase/11/docs/api/",
         "maven": "maven_3_latest",
         "mavenversion": "dev-SNAPSHOT",

--- a/vars/asfMainNetBeansBuild.groovy
+++ b/vars/asfMainNetBeansBuild.groovy
@@ -123,6 +123,11 @@ def call(Map params = [:]) {
                         //2018-07-29T12:00:00Z
                         atomdate = releaseInformation[branch].releasedate['year']+'-'+releaseInformation[branch].releasedate['month']+'-'+releaseInformation[branch].releasedate['day']+'T12:00:00Z'
                         tooling.jdktool = releaseInformation[branch].jdk
+                        if (releaseInformation[branch].jdktoolapidoc) {
+                            tooling.jdktoolapidoc = releaseInformation[branch].jdktoolapidoc
+                        }else {
+                            tooling.jdktoolapidoc = releaseInformation[branch].jdk
+                        }
                         tooling.myMaven = releaseInformation[branch].maven
                         version = releaseInformation[branch].versionName;
                         vsixversion = releaseInformation[branch].vsixVersion;
@@ -163,6 +168,9 @@ def call(Map params = [:]) {
                                 sh "ant getallmavencoordinates"
                                 sh "ant build-nbms"
                                 sh "ant build-source-zips"
+                            }
+                            withAnt(installation: tooling.myAnt, jdk: tooling.jdktoolapidoc) {
+
                                 sh "ant build-javadoc -Djavadoc.web.zip=${env.WORKSPACE}/WEBZIP.zip"
 
                                 junit 'nbbuild/build/javadoc/checklinks-errors.xml'
@@ -212,6 +220,8 @@ def call(Map params = [:]) {
                         steps {
                             withAnt(installation: tooling.myAnt) {
                                 sh "ant"
+                            }
+                            withAnt(installation: tooling.myAnt, jdk: tooling.jdktoolapidoc) {
                                 sh "ant build-javadoc -Djavadoc.web.zip=${env.WORKSPACE}/WEBZIP.zip"
                             }
                             junit 'nbbuild/build/javadoc/checklinks-errors.xml'


### PR DESCRIPTION
It's a non sure it works PR to test if I can build apidoc using another version of the JDK (19 at the moment) on master. If no apidocjdk should default to main jdk.

