### PR TITLE
JSON for VSCode releases added, decoupling from main NetBeans IDE releases.

### DIFF
--- a/meta/README
+++ b/meta/README
@@ -18,5 +18,9 @@
 -->
 
 Json file containing release information for Apache NetBeans.
+`meta` folder content:
+  * `netbeansrelease.json` - Release information for Apache NetBeans IDE releases. Then main Release.
+  * `netbeanshtml4j.json` - Release information for  [Html 4 Java](https://github.com/apache/netbeans-html4j) project
+  * `netbeansvscode.json` - Release information for Apache NetBeans Langauge Server for VSCode. Decoupled from netbeansrelease.json in v. 26.0.
 
 Json cannot contains ASF Header

--- a/meta/netbeansvscode.json
+++ b/meta/netbeansvscode.json
@@ -1,0 +1,57 @@
+{
+    "release2600": {
+        "position": "1",
+        "ant": "ant_latest",
+        "jdk": "jdk_17_latest",
+        "jdktoolapidoc" : "jdk_24_latest",
+        "jdk_apidoc": "https://docs.oracle.com/en/java/javase/24/docs/api/",
+        "maven": "maven_3_latest",
+        "mavenversion": "RELEASE260",
+        "versionName": "26.0.0",
+        "vsixVersion": "26.0.0",
+        "tlp": "true",
+        "apidocurl": "https://bits.netbeans.org/26/javadoc",
+        "publish_apidoc":"false",
+        "milestones": {
+            "27b43e77690d92eaf5d90e23d77b4626145c4d3f": {
+                "version": "rc1",
+                "position": "1"
+            }
+        },
+        "releasedate": {
+            "day": "-",
+            "month": "-",
+            "year": "-"
+        },
+        "previousreleasedate": {
+            "day": "20",
+            "month": "02",
+            "year": "2025"
+        }
+    },
+    "master": {
+        "position": "50000",
+        "ant": "ant_latest",
+        "jdk": "jdk_17_latest",
+        "jdktoolapidoc" : "jdk_24_latest",
+        "jdk_apidoc": "https://docs.oracle.com/en/java/javase/24/docs/api/",
+        "maven": "maven_3_latest",
+        "mavenversion": "dev-SNAPSHOT",
+        "versionName": "dev",
+        "tlp": "true",
+        "apidocurl": "https://bits.netbeans.org/dev/javadoc",
+        "update_url": "https://netbeans.apache.org/nb/updates/dev/updates.xml.gz?{$netbeans.hash.code}",
+        "plugin_url": "https://netbeans.apache.org/nb/plugins/dev/catalog.xml.gz",
+        "publish_apidoc":"true",
+        "releasedate": {
+            "day": "-",
+            "month": "-",
+            "year": "-"
+        },
+        "previousreleasedate": {
+            "day": "20",
+            "month": "02",
+            "year": "2025"
+        }
+    }
+}


### PR DESCRIPTION
Created new `netbeansvscode.json` in `meta` folder to decouple releases of VSCode ext from main NetBeans IDE. Omitted `update_url` and `plugin_url` in netbeansvscode.json as it is not needed for VSIX. When required it can be put back. Updated  README.MD with what is what. 