### PR TITLE
Remove .gz from dev updates url.

### DIFF
--- a/meta/netbeansrelease.json
+++ b/meta/netbeansrelease.json
@@ -1614,7 +1614,7 @@
         "versionName": "dev",
         "tlp": "true",
         "apidocurl": "https://bits.netbeans.org/dev/javadoc",
-        "update_url": "https://netbeans.apache.org/nb/updates/dev/updates.xml.gz?{$netbeans.hash.code}",
+        "update_url": "https://netbeans.apache.org/nb/updates/dev/updates.xml?{$netbeans.hash.code}",
         "plugin_url": "https://netbeans.apache.org/nb/plugins/dev/catalog.xml.gz",
         "publish_apidoc":"true",
         "releasedate": {


### PR DESCRIPTION
I've updated the .htaccess so that dev builds point to the same empty updates as NB26.  Will also have the benefit of no more "update your IDE" notifications in delivery branch builds!

Needed a temporary redirect of the .gz link to stop errors (although still gives logs it's not GZip) - https://github.com/apache/netbeans-antora/blob/main/supplemental-ui/.htaccess#L71  That can be removed once the change here propagates.